### PR TITLE
Fix numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Add the following as another function in the App class:
 
 A GET request to this route will display pages of data representing the photo, which is not very human readable. To solve this, we will make a new route which only returns the meal name and rating.
 
-5. Register a handler for a `GET` request on `/summary` that loads the data  
+5. Register a handler for a `GET` request on `/summary` that loads the data.  
 Add the following into the `postInit()` function:  
 ```swift
 	router.get("/summary", handler: summaryHandler)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you would like to jump straight to one of these next steps a completed versio
    ```
 
 ## Getting Started
-### 1. Run the Food Tracker App:
+### Run the Food Tracker App:
 The Food Tracker application is taken from the Apple tutorial for building your first iOS application. It allows you to store names, photos and ratings for  "meals". The meals are then stored onto the device using `NSKeyedArchiver`. The following shows you how to see the application running.
 
 1. Change into the iOS app directory:  
@@ -143,7 +143,8 @@ Add the following as another function in the App class:
     }
 ```
 
-A GET request to this route you will display pages of data representing the photo, which is not very human readable. To solve this, we will make a new route which only returns the meal name and rating.
+A GET request to this route will display pages of data representing the photo, which is not very human readable. To solve this, we will make a new route which only returns the meal name and rating.
+
 5. Register a handler for a `GET` request on `/summary` that loads the data  
 Add the following into the `postInit()` function:  
 ```swift
@@ -441,17 +442,17 @@ do {
 
 Before we start using the PostgreSQL Database, we need to create a table in the database. Add the following:
 
-2. Add the `@escaping` keyword to the completion closure in the `storeHandler`  signatures.
+4. Add the `@escaping` keyword to the completion closure in the `storeHandler`  signatures.
 ```swift
 func storeHandler(meal: Meal, completion: @escaping (Meal?, RequestError?) -> Void ) {
 ```
 
-3. Add the `@escaping` keyword to the completion closure in the `loadHandler`  signatures.
+5. Add the `@escaping` keyword to the completion closure in the `loadHandler`  signatures.
 ```swift
 func loadHandler(completion: @escaping ([Meal]?, RequestError?) -> Void ) {
 ```
 
-4. Add the `@escaping` keyword to the completion closure in the `summaryHandler`  signatures.
+6. Add the `@escaping` keyword to the completion closure in the `summaryHandler`  signatures.
 ```swift
 func summaryHandler(completion: @escaping (Summary?, RequestError?) -> Void ) {
 ```
@@ -481,6 +482,7 @@ You can verify this by:
 4. Viewing your meals table:
 `SELECT name, rating FROM meals;`
 This should produce a table with the name and the rating of your newly added meal.
+
 **NOTE** We do not print out the photo because it is too large
 
 
@@ -504,7 +506,7 @@ func loadHandler(completion: @escaping ([Meal]?, RequestError?) -> Void ) {
 Now when you perform a `GET` call to your server it will retrieve the meals from your database.
 
 Update the summaryHandler function to get the meals from the database:
-1.  Inside the `summaryHandler` function add the following line:
+3.  Inside the `summaryHandler` function add the following line:
 ```swift
 Meal.findAll { meals, error in
     guard let meals = meals else {
@@ -515,7 +517,7 @@ Meal.findAll { meals, error in
 }
 ```
 
-2. Your completed `summaryHandler` function should now look as follows:
+4. Your completed `summaryHandler` function should now look as follows:
 ```swift
 func summaryHandler(completion: @escaping ([Summary]?, RequestError?) -> Void ) {
     Meal.findAll { meals, error in


### PR DESCRIPTION
Fixed an issue with the numbering in the Food tracker tutorial README.

This makes the numbers count consistantly and adds a space to cause number 5 in "Run the Food Tracker App:" to display correctly